### PR TITLE
Fix parsing validation errors

### DIFF
--- a/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
+++ b/Octokit.Tests/Exceptions/ApiValidationExceptionTests.cs
@@ -29,6 +29,20 @@ namespace Octokit.Tests.Exceptions
             }
 
             [Fact]
+            public void CreatesGitHubErrorFromJsonValidationResponse()
+            {
+                var response = CreateResponse((HttpStatusCode)422, @"{""message"":""Unprocessable Entity"",""errors"":[""Can not approve your own pull request""],""documentation_url"":""https://docs.github.com/rest/reference/pulls#create-a-review-for-a-pull-request""}");
+
+                var exception = new ApiValidationException(response);
+
+                Assert.Equal("Unprocessable Entity", exception.Message);
+                Assert.Equal("Unprocessable Entity", exception.ApiError.Message);
+                Assert.Equal("Can not approve your own pull request", exception.ApiError.Errors.First().Message);
+                Assert.Equal("https://docs.github.com/rest/reference/pulls#create-a-review-for-a-pull-request", exception.ApiError.DocumentationUrl);
+            }
+
+
+            [Fact]
             public void ProvidesDefaultMessage()
             {
                 var response = CreateResponse((HttpStatusCode)422);

--- a/Octokit/Exceptions/ApiException.cs
+++ b/Octokit/Exceptions/ApiException.cs
@@ -136,6 +136,14 @@ namespace Octokit
             }
             catch (Exception)
             {
+                try
+                {
+                    return new ApiError(_jsonSerializer.Deserialize<ApiError.SimpleApiError>(responseContent));
+
+                }
+                catch (Exception)
+                {
+                }
             }
 
             return new ApiError(responseContent);

--- a/Octokit/Models/Response/ApiError.cs
+++ b/Octokit/Models/Response/ApiError.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Linq;
 
 namespace Octokit
 {
@@ -28,6 +29,13 @@ namespace Octokit
             Errors = errors;
         }
 
+        internal ApiError(SimpleApiError simpleApiError)
+        {
+            Message = simpleApiError.Message;
+            DocumentationUrl = simpleApiError.DocumentationUrl;
+            Errors = simpleApiError.Errors.Select(e => new ApiErrorDetail(e)).ToArray();
+        }
+
         /// <summary>
         /// The error message
         /// </summary>
@@ -49,6 +57,19 @@ namespace Octokit
             {
                 return string.Format(CultureInfo.InvariantCulture, "Message: {0}", Message);
             }
+        }
+
+        /// <summary>
+        /// Simple API Error class to deserialize errors as plain string
+        /// </summary>
+        internal class SimpleApiError
+        {
+            public SimpleApiError() { }
+
+            public string Message { get; protected set; }
+            public string DocumentationUrl { get; protected set; }
+
+            public IReadOnlyList<string> Errors { get; protected set; }
         }
     }
 }

--- a/Octokit/Models/Response/ApiErrorDetail.cs
+++ b/Octokit/Models/Response/ApiErrorDetail.cs
@@ -10,7 +10,10 @@ namespace Octokit
     [DebuggerDisplay("{DebuggerDisplay,nq}")]
     public class ApiErrorDetail
     {
-        public ApiErrorDetail() { }
+        public ApiErrorDetail(string message)
+        {
+            Message = message;
+        }
 
         public ApiErrorDetail(string message, string code, string field, string resource)
         {


### PR DESCRIPTION
The default parsing does not work with validation error, I couldn't find any documentation on the subject so I tried not to break the existing parsing to be retro compatible.  